### PR TITLE
A route change and a spelling edit in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ A kid has come to you with an idea for an API to keep track of his candies.  You
 - Create an Express app from scratch
 - This app will only respond to JSON; it is just an API, so don't worry about the views
 - The resource `Candy` should be accessible via the endpoint `/candies` and be RESTful
-- Implement `index`,`show`, `create`, `update`, and `destory` functionality
+- Implement `index`,`show`, `create`, `update`, and `destroy` functionality
 
 **Bonus:**
 - Handle wrong responses with appropriate HTTP status and responses (404, 500, 422)

--- a/solution-code/controllers/candies.js
+++ b/solution-code/controllers/candies.js
@@ -42,7 +42,7 @@ router.route('/:id').get(function(req,res){
   .put(function(req, res) {
     for(var i in candies){
       if(candies[i]["id"] == req.params.id){
-        candies[i] = req.body;
+        candies[i] = {id:candies[i]["id"], name:req.body.name, color:req.body.color}
       }
     }
     res.format({

--- a/solution-code/controllers/candies.js
+++ b/solution-code/controllers/candies.js
@@ -37,19 +37,18 @@ router.route('/:id').get(function(req,res){
       }
     }
     res.json({message : 'deleted' });
-  });
-
-//Update a candy
-router.put('/:id/edit', function(req, res) {
-  for(var i in candies){
-    if(candies[i]["id"] == req.params.id){
-      candies[i] = req.body;
+  })
+  //Update a candy
+  .put(function(req, res) {
+    for(var i in candies){
+      if(candies[i]["id"] == req.params.id){
+        candies[i] = req.body;
+      }
     }
-  }
-  res.format({
-    json: function(){ res.json(req.body); }
+    res.format({
+      json: function(){ res.json(req.body); }
+    });
   });
-});
 
 
 module.exports = router;


### PR DESCRIPTION
For the UPDATE, the instructions for this lesson say:
> curl -XPUT -H "Content-Type: application/json" -d '{"name":"Marshmallows","color":"white"}' http://localhost:3000/candies/3

Since the URL used is ../candies/3 and not ../candies/3/edit, the PUT route needed to be changed, and can be chained to the /:id route.

Also, the object passed has only "name" and "color", so the original code would overwrite a three-key object with a two-key one.  The suggested edit preserves the "id" value of the changed object.

Alternatively, you could just edit the instructions to show for UPDATE:
> curl -XPUT -H "Content-Type: application/json" -d '{"id":3,"name":"Marshmallows","color":"white"}' http://localhost:3000/candies/3/edit